### PR TITLE
ButtonVisible added as Boolean

### DIFF
--- a/ag.WPF.ColorPicker/ColorPicker.cs
+++ b/ag.WPF.ColorPicker/ColorPicker.cs
@@ -46,6 +46,10 @@ namespace ag.WPF.ColorPicker
         /// The identifier of the <see cref="ColorString"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty ColorStringProperty = DependencyProperty.Register(nameof(ColorString), typeof(string), typeof(ColorPicker), new FrameworkPropertyMetadata(""));
+        /// <summary>
+        /// The identifier of the <see cref="ButtonVisible"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty ButtonVisibleProperty = DependencyProperty.Register(nameof(ButtonVisible), typeof(bool), typeof(ColorPicker), new FrameworkPropertyMetadata(true));
         #endregion
 
         /// <summary>
@@ -83,6 +87,15 @@ namespace ag.WPF.ColorPicker
         {
             get { return (string)GetValue(ColorStringProperty); }
             private set { SetValue(ColorStringProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the visibility of the Button.
+        /// </summary>
+        public bool ButtonVisible
+        {
+            get { return (bool)GetValue(ButtonVisibleProperty); }
+            set { SetValue(ButtonVisibleProperty, value); }
         }
 
         #endregion

--- a/ag.WPF.ColorPicker/Themes/Generic.xaml
+++ b/ag.WPF.ColorPicker/Themes/Generic.xaml
@@ -653,6 +653,7 @@
                             <Button x:Name="PART_Button"
                                     Margin="1"
                                     Grid.Column="1"
+                                    Visibility="{Binding Path=ButtonVisible, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource BooleanToVisibilityConverter}}"
                                     Padding="2">
                                 <Viewbox Stretch="Fill">
                                     <Grid>


### PR DESCRIPTION
I added the DependencyProperty "ButtonVisible" as boolean, so the button could be disabled by a simple "false" flag, but its standard is still true, so for everyone else nothing changes.